### PR TITLE
Add per-lot holdings tracking and realized P&L on sells

### DIFF
--- a/backend-dev/api_documentation.md
+++ b/backend-dev/api_documentation.md
@@ -1,0 +1,280 @@
+# Coral Xchange API Documentation
+
+## Base URL
+
+```
+http://localhost:8080
+```
+
+---
+
+# Endpoints
+
+---
+
+## 1. Health Check
+
+### GET `/`
+
+**Description:** Returns welcome message
+
+**Response**
+
+```json
+"Welcome to the Coral Xchange API!"
+```
+
+---
+
+## 2. Portfolio
+
+### GET `/api/v1/portfolio`
+
+**Description:** Get user holdings and total portfolio value
+
+**Response**
+
+```json
+{
+  "holdings": [
+    {
+      "ticker": "AAPL",
+      "quantity": 50,
+      "price": 150
+    }
+  ],
+  "totalValue": 7500
+}
+```
+
+---
+
+## 3. Account
+
+### GET `/api/v1/account`
+
+**Description:** Get account balance
+
+**Response**
+
+```json
+{
+  "userID": 1,
+  "cashBalance": 100000
+}
+```
+
+**Errors**
+
+```json
+{
+  "error": "Could not retrieve account balance"
+}
+```
+
+---
+
+## 4. Trades
+
+### GET `/api/v1/trades`
+
+**Description:** Get all trades (currently empty)
+
+**Response**
+
+```json
+{
+  "trades": []
+}
+```
+
+---
+
+### POST `/api/v1/trade`
+
+**Description:** Place a trade (BUY or SELL)
+
+**Request Body**
+
+```json
+{
+  "symbol": "AAPL",
+  "side": "BUY",
+  "quantity": 10
+}
+```
+
+**Response**
+
+```json
+{
+  "status": "FILLED",
+  "symbol": "AAPL",
+  "side": "BUY",
+  "quantity": 10,
+  "price": 100,
+  "remainingCash": 90000
+}
+```
+
+**Errors**
+
+Invalid body:
+
+```json
+{
+  "error": "invalid request body"
+}
+```
+
+Insufficient funds:
+
+```json
+{
+  "error": "Insufficient funds"
+}
+```
+
+Invalid side:
+
+```json
+{
+  "error": "Invalid trade side. Must be 'BUY' or 'SELL'"
+}
+```
+
+Insufficient holdings:
+
+```json
+{
+  "error": "Insufficient holdings to sell"
+}
+```
+
+---
+
+## 5. Prices
+
+### GET `/api/v1/prices?symbols=AAPL,GOOG`
+
+**Description:** Get stock prices
+
+**Query Params**
+
+* `symbols` (string, comma-separated)
+
+**Response**
+
+```json
+{
+  "requested": "AAPL,GOOG",
+  "prices": {
+    "AAPL": 100,
+    "GOOG": 200
+  }
+}
+```
+
+---
+
+## 6. Search Stocks
+
+### GET `/api/v1/searchStocks?query=apple`
+
+**Description:** Search for stocks using external API
+
+**Query Params**
+
+* `query` (string)
+
+**Response**
+
+```json
+[
+  {
+    "symbol": "AAPL",
+    "name": "Apple Inc."
+  }
+]
+```
+
+**Errors**
+
+No results:
+
+```json
+{
+  "message": "No stocks found"
+}
+```
+
+API failure:
+
+```json
+{
+  "error": "Failed to reach API"
+}
+```
+
+---
+
+## 7. Stock Quote
+
+### GET `/api/v1/quote/:ticker`
+
+**Description:** Get detailed stock quote
+
+**Path Params**
+
+* `ticker` (string)
+
+**Response**
+
+```json
+{
+  "ticker": "AAPL",
+  "name": "Apple Inc.",
+  "price": 150,
+  "day_high": 155,
+  "day_low": 148,
+  "day_open": 149,
+  "day_change": 1.5,
+  "volume": 1000000,
+  "52_week_high": 180,
+  "52_week_low": 120,
+  "last_trade_time": "2026-03-24T10:00:00Z"
+}
+```
+
+**Errors**
+
+Ticker not found:
+
+```json
+{
+  "error": "Ticker not found"
+}
+```
+
+API failure:
+
+```json
+{
+  "error": "API unreachable"
+}
+```
+
+---
+
+# Summary
+
+| Method | Endpoint                | Description         |
+| ------ | ----------------------- | ------------------- |
+| GET    | `/`                     | Welcome message     |
+| GET    | `/api/v1/portfolio`     | Get portfolio       |
+| GET    | `/api/v1/account`       | Get account balance |
+| GET    | `/api/v1/trades`        | Get trades          |
+| POST   | `/api/v1/trade`         | Place trade         |
+| GET    | `/api/v1/prices`        | Get stock prices    |
+| GET    | `/api/v1/searchStocks`  | Search stocks       |
+| GET    | `/api/v1/quote/:ticker` | Get stock quote     |

--- a/backend-dev/database.go
+++ b/backend-dev/database.go
@@ -21,7 +21,7 @@ func initDatabase(database *sql.DB) {
 		// Users table — the anchor for every other table.
 		`CREATE TABLE IF NOT EXISTS users (
 			id            INTEGER PRIMARY KEY AUTOINCREMENT,
-			name 		  TEXT NOT NULL,
+			name          TEXT NOT NULL,
 			username      TEXT UNIQUE NOT NULL,
 			email         TEXT UNIQUE NOT NULL,
 			password_hash TEXT NOT NULL,
@@ -35,13 +35,33 @@ func initDatabase(database *sql.DB) {
 			FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 		)`,
 
-		// Each holding is scoped to a user.
+		// Each row is one purchase lot for one user.
+		// Multiple rows per (user_id, ticker) are intentional — each BUY
+		// creates a new lot so the purchase price is preserved for
+		// realized P&L calculation. purchased_at drives FIFO ordering
+		// when shares are sold.
 		`CREATE TABLE IF NOT EXISTS holdings (
-			id       INTEGER PRIMARY KEY AUTOINCREMENT,
-			user_id  INTEGER NOT NULL,
-			ticker   TEXT    NOT NULL,
-			quantity INTEGER NOT NULL,
-			price    REAL    NOT NULL,
+			id           INTEGER PRIMARY KEY AUTOINCREMENT,
+			user_id      INTEGER  NOT NULL,
+			ticker       TEXT     NOT NULL,
+			quantity     INTEGER  NOT NULL,
+			price        REAL     NOT NULL,
+			purchased_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+		)`,
+
+		// Each row is one completed SELL trade.
+		// cost_basis   — what the sold shares originally cost (sum across lots consumed)
+		// realized_pnl — profit (positive) or loss (negative) locked in by the sale
+		`CREATE TABLE IF NOT EXISTS trades (
+			id           INTEGER PRIMARY KEY AUTOINCREMENT,
+			user_id      INTEGER NOT NULL,
+			ticker       TEXT    NOT NULL,
+			quantity     INTEGER NOT NULL,
+			sell_price   REAL    NOT NULL,
+			cost_basis   REAL    NOT NULL,
+			realized_pnl REAL    NOT NULL,
+			sold_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 		)`,
 	}

--- a/backend-dev/handlers.go
+++ b/backend-dev/handlers.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,8 +25,16 @@ func welcome(c *gin.Context) {
 func getPortfolio(c *gin.Context) {
 	userID := getUserID(c)
 
+	// Aggregate all lots per ticker, computing total quantity and average cost basis.
 	rows, err := db.Query(
-		`SELECT ticker, quantity, price FROM holdings WHERE user_id = ?`, userID,
+		`SELECT
+			ticker,
+			SUM(quantity)                              AS total_qty,
+			SUM(quantity * price) / SUM(quantity)      AS avg_price
+		FROM holdings
+		WHERE user_id = ?
+		GROUP BY ticker`,
+		userID,
 	)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -41,18 +48,21 @@ func getPortfolio(c *gin.Context) {
 	for rows.Next() {
 		var ticker string
 		var quantity int
-		var price float64
+		var avgPrice float64
 
-		if err := rows.Scan(&ticker, &quantity, &price); err != nil {
+		if err := rows.Scan(&ticker, &quantity, &avgPrice); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
 
-		totalValue += float64(quantity) * price
+		positionValue := float64(quantity) * avgPrice
+		totalValue += positionValue
+
 		holdings = append(holdings, gin.H{
-			"ticker":   ticker,
-			"quantity": quantity,
-			"price":    price,
+			"ticker":        ticker,
+			"quantity":      quantity,
+			"avgCostBasis":  avgPrice,
+			"positionValue": positionValue,
 		})
 	}
 
@@ -60,6 +70,51 @@ func getPortfolio(c *gin.Context) {
 		"holdings":   holdings,
 		"totalValue": totalValue,
 	})
+}
+
+// GET /api/v1/holdings
+// Returns every individual purchase lot so the client can see per-lot cost basis.
+func getHoldings(c *gin.Context) {
+	userID := getUserID(c)
+
+	rows, err := db.Query(
+		`SELECT ticker, quantity, price, purchased_at
+		FROM holdings
+		WHERE user_id = ?
+		ORDER BY ticker ASC, purchased_at ASC`,
+		userID,
+	)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	defer rows.Close()
+
+	var lots []gin.H
+	for rows.Next() {
+		var ticker, purchasedAt string
+		var quantity int
+		var price float64
+
+		if err := rows.Scan(&ticker, &quantity, &price, &purchasedAt); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		lots = append(lots, gin.H{
+			"ticker":      ticker,
+			"quantity":    quantity,
+			"price":       price,
+			"purchasedAt": purchasedAt,
+		})
+	}
+
+	// Return an empty array rather than null if there are no lots yet.
+	if lots == nil {
+		lots = []gin.H{}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"lots": lots})
 }
 
 // GET /api/v1/account
@@ -83,10 +138,50 @@ func getAccount(c *gin.Context) {
 }
 
 // GET /api/v1/trades
+// Returns the full sell history with realized P&L for each trade.
 func getTrades(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{
-		"trades": []gin.H{},
-	})
+	userID := getUserID(c)
+
+	rows, err := db.Query(
+		`SELECT ticker, quantity, sell_price, cost_basis, realized_pnl, sold_at
+		FROM trades
+		WHERE user_id = ?
+		ORDER BY sold_at DESC`,
+		userID,
+	)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	defer rows.Close()
+
+	var trades []gin.H
+	for rows.Next() {
+		var ticker, soldAt string
+		var quantity int
+		var sellPrice, costBasis, realizedPnL float64
+
+		if err := rows.Scan(&ticker, &quantity, &sellPrice, &costBasis, &realizedPnL, &soldAt); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		trades = append(trades, gin.H{
+			"ticker":      ticker,
+			"quantity":    quantity,
+			"sellPrice":   sellPrice,
+			"costBasis":   costBasis,
+			"realizedPnL": realizedPnL,
+			"soldAt":      soldAt,
+		})
+	}
+
+	// Return an empty array rather than null if there are no trades yet.
+	if trades == nil {
+		trades = []gin.H{}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"trades": trades})
 }
 
 type QuoteResponse struct {
@@ -146,7 +241,7 @@ func placeTrade(c *gin.Context) {
 		return
 	}
 
-	// Fetch real-time price before doing anything else
+	// Fetch real-time price before doing anything else.
 	quoteRes, err := getQuoteData(req.Symbol)
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
@@ -170,6 +265,10 @@ func placeTrade(c *gin.Context) {
 	}
 
 	switch req.Side {
+
+	// -----------------------------------------------------------------------
+	// BUY — always insert a new lot so we preserve the purchase price.
+	// -----------------------------------------------------------------------
 	case "BUY":
 		tradeCost := float64(req.Quantity) * stockPrice
 		if balance < tradeCost {
@@ -186,62 +285,127 @@ func placeTrade(c *gin.Context) {
 			return
 		}
 
-		var existingQty int
-		err = db.QueryRow(
-			"SELECT quantity FROM holdings WHERE user_id = ? AND ticker = ?", userID, req.Symbol,
-		).Scan(&existingQty)
-
-		if err == sql.ErrNoRows {
-			res, err := db.Exec(
-				"INSERT INTO holdings (user_id, ticker, quantity, price) VALUES (?, ?, ?, ?)",
-				userID, req.Symbol, req.Quantity, stockPrice,
-			)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not insert holding"})
-				return
-			}
-			if ra, _ := res.RowsAffected(); ra == 0 {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "No rows inserted into holdings"})
-				return
-			}
-		} else if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not query holdings"})
+		// Each purchase becomes its own row so per-lot cost basis is preserved.
+		_, err = db.Exec(
+			"INSERT INTO holdings (user_id, ticker, quantity, price) VALUES (?, ?, ?, ?)",
+			userID, req.Symbol, req.Quantity, stockPrice,
+		)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not insert holding"})
 			return
-		} else {
-			res, err := db.Exec(
-				"UPDATE holdings SET quantity = quantity + ?, price = ? WHERE user_id = ? AND ticker = ?",
-				req.Quantity, stockPrice, userID, req.Symbol,
-			)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not update holding"})
-				return
-			}
-			if ra, _ := res.RowsAffected(); ra == 0 {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "No rows updated in holdings"})
-				return
-			}
 		}
+
 		balance -= tradeCost
 
+	// -----------------------------------------------------------------------
+	// SELL — consume lots oldest-first (FIFO) at today's market price.
+	//
+	// For each lot consumed we calculate:
+	//   realized P&L = (sell price - lot buy price) × shares sold from that lot
+	// The total across all lots consumed is recorded in the trades table.
+	// -----------------------------------------------------------------------
 	case "SELL":
-		var quantity int
+		// Confirm the user owns enough shares across all lots.
+		var totalQty int
 		err := db.QueryRow(
-			"SELECT quantity FROM holdings WHERE user_id = ? AND ticker = ?", userID, req.Symbol,
-		).Scan(&quantity)
-
-		if err == sql.ErrNoRows {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "You do not own any shares of " + req.Symbol})
-			return
-		} else if err != nil {
+			"SELECT COALESCE(SUM(quantity), 0) FROM holdings WHERE user_id = ? AND ticker = ?",
+			userID, req.Symbol,
+		).Scan(&totalQty)
+		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not retrieve holdings"})
 			return
 		}
-
-		if quantity < req.Quantity {
+		if totalQty == 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "You do not own any shares of " + req.Symbol})
+			return
+		}
+		if totalQty < req.Quantity {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Insufficient holdings to sell"})
 			return
 		}
 
+		// Fetch lots oldest-first for FIFO consumption.
+		// We also select each lot's buy price to compute realized P&L.
+		lotRows, err := db.Query(
+			`SELECT id, quantity, price FROM holdings
+			WHERE user_id = ? AND ticker = ?
+			ORDER BY purchased_at ASC, id ASC`,
+			userID, req.Symbol,
+		)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not retrieve holdings"})
+			return
+		}
+
+		type lot struct {
+			id       int
+			qty      int
+			buyPrice float64
+		}
+		var lots []lot
+		for lotRows.Next() {
+			var l lot
+			if err := lotRows.Scan(&l.id, &l.qty, &l.buyPrice); err != nil {
+				lotRows.Close()
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not read holding"})
+				return
+			}
+			lots = append(lots, l)
+		}
+		lotRows.Close()
+
+		// Walk lots FIFO, consuming shares and accumulating cost basis + realized P&L.
+		remaining := req.Quantity
+		var totalCostBasis float64
+		var totalRealizedPnL float64
+
+		for _, l := range lots {
+			if remaining == 0 {
+				break
+			}
+
+			// How many shares are we taking from this lot?
+			sharesFromLot := l.qty
+			if sharesFromLot > remaining {
+				sharesFromLot = remaining
+			}
+
+			// Tally this lot's contribution to the overall cost basis and P&L.
+			totalCostBasis += float64(sharesFromLot) * l.buyPrice
+			totalRealizedPnL += float64(sharesFromLot) * (stockPrice - l.buyPrice)
+
+			if l.qty <= remaining {
+				// Entire lot consumed — remove the row.
+				if _, err := db.Exec("DELETE FROM holdings WHERE id = ?", l.id); err != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not delete holding lot"})
+					return
+				}
+			} else {
+				// Lot partially consumed — reduce its quantity.
+				if _, err := db.Exec(
+					"UPDATE holdings SET quantity = quantity - ? WHERE id = ?",
+					remaining, l.id,
+				); err != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not update holding lot"})
+					return
+				}
+			}
+
+			remaining -= sharesFromLot
+		}
+
+		// Record the completed sell trade with its realized P&L.
+		_, err = db.Exec(
+			`INSERT INTO trades (user_id, ticker, quantity, sell_price, cost_basis, realized_pnl)
+			VALUES (?, ?, ?, ?, ?, ?)`,
+			userID, req.Symbol, req.Quantity, stockPrice, totalCostBasis, totalRealizedPnL,
+		)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not record trade"})
+			return
+		}
+
+		// Credit the account at the current market price.
 		tradeProceeds := float64(req.Quantity) * stockPrice
 		_, err = db.Exec(
 			"UPDATE account SET cash_balance = cash_balance + ? WHERE user_id = ?",
@@ -249,14 +413,6 @@ func placeTrade(c *gin.Context) {
 		)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not update account balance"})
-			return
-		}
-		_, err = db.Exec(
-			"UPDATE holdings SET quantity = quantity - ?, price = ? WHERE user_id = ? AND ticker = ?",
-			req.Quantity, stockPrice, userID, req.Symbol,
-		)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not update holdings"})
 			return
 		}
 		balance += tradeProceeds
@@ -316,8 +472,6 @@ func searchStocks(c *gin.Context) {
 
 	c.JSON(http.StatusOK, searchRes.Data)
 }
-
-
 
 // GET /api/v1/quote/:ticker
 func getStockQuote(c *gin.Context) {

--- a/backend-dev/schema.sql
+++ b/backend-dev/schema.sql
@@ -1,6 +1,6 @@
 -- coral-xchange schema
 -- Run "PRAGMA foreign_keys = ON" at connection time (handled in Go).
- 
+
 CREATE TABLE IF NOT EXISTS users (
     id            INTEGER PRIMARY KEY AUTOINCREMENT,
     name          TEXT NOT NULL,
@@ -9,21 +9,39 @@ CREATE TABLE IF NOT EXISTS users (
     password_hash TEXT NOT NULL,
     created_at    DATETIME DEFAULT CURRENT_TIMESTAMP
 );
- 
+
 -- One account per user, provisioned automatically on registration.
 CREATE TABLE IF NOT EXISTS account (
     user_id      INTEGER PRIMARY KEY,
     cash_balance REAL NOT NULL DEFAULT 100000.00,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
- 
--- Each row is one ticker position for one user.
+
+-- Each row is one purchase lot for one user.
+-- Multiple rows per (user_id, ticker) are intentional — each BUY creates a
+-- new lot so the purchase price is preserved for realized P&L calculation.
+-- purchased_at drives FIFO ordering when shares are sold.
 CREATE TABLE IF NOT EXISTS holdings (
-    id       INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id  INTEGER NOT NULL,
-    ticker   TEXT    NOT NULL,
-    quantity INTEGER NOT NULL,
-    price    REAL    NOT NULL,
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      INTEGER  NOT NULL,
+    ticker       TEXT     NOT NULL,
+    quantity     INTEGER  NOT NULL,
+    price        REAL     NOT NULL,
+    purchased_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
- 
+
+-- Each row is one completed SELL trade.
+-- cost_basis   — what the sold shares originally cost (sum across lots consumed)
+-- realized_pnl — profit (positive) or loss (negative) locked in by the sale
+CREATE TABLE IF NOT EXISTS trades (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      INTEGER  NOT NULL,
+    ticker       TEXT     NOT NULL,
+    quantity     INTEGER  NOT NULL,
+    sell_price   REAL     NOT NULL,
+    cost_basis   REAL     NOT NULL,
+    realized_pnl REAL     NOT NULL,
+    sold_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
Previously, the holdings table stored a single row per stock that got overwritten on every buy, making it impossible to track what price each stock was purchased at.
Now the holdings table updated to store each purchase separately, preserving the exact price paid. When shares are sold, the realized profit or loss is calculated by comparing the original purchase price against the sell price, and saved to a new trades table for history tracking.